### PR TITLE
changed neutronics_material to openmc_material

### DIFF
--- a/tasks/task_10/example_CAD_simulation.py
+++ b/tasks/task_10/example_CAD_simulation.py
@@ -12,11 +12,11 @@ from parametric_plasma_source import Plasma
 
 # MATERIALS using the neutronics material maker
 
-breeder_material = Material(material_name='Li4SiO4', enrichment=90).neutronics_material
+breeder_material = Material(material_name='Li4SiO4', enrichment=90).openmc_material
 
-copper = Material(material_name="copper").neutronics_material
+copper = Material(material_name="copper").openmc_material
 
-eurofer = Material(material_name='eurofer').neutronics_material
+eurofer = Material(material_name='eurofer').openmc_material
 
 mats = openmc.Materials([breeder_material, eurofer, copper])
 

--- a/tasks/task_11/3_example_materials_from_material_maker.py
+++ b/tasks/task_11/3_example_materials_from_material_maker.py
@@ -15,10 +15,10 @@ print(water)
 
 # the following command converts Material() objects into neutronics materials which can be used in OpenMC
 
-water_openmc_material_object = water.neutronics_material
+water_openmc_material_object = water.openmc_material
 # this is equivalent to:
 
-# water_openmc_material_object = Material('H2O', temperature_in_C=25, pressure_in_Pa=100000).neutronics_material
+# water_openmc_material_object = Material('H2O', temperature_in_C=25, pressure_in_Pa=100000).openmc_material
 
 print(type(water_openmc_material_object))
 print(water_openmc_material_object)
@@ -29,11 +29,11 @@ print(water_openmc_material_object)
 # Lithium Orthosilicate (Li4SiO4) can take arguments of 'enrichment', 'enrichment_target', 'enrichment_type' and 'packing_fraction'
 # Note: for some lithium crystals, 'enrichment_target' and 'enrichment_type' are defined by default, but can be changed
 
-default_Li4SiO4 = Material('Li4SiO4').neutronics_material
+default_Li4SiO4 = Material('Li4SiO4').openmc_material
 print(default_Li4SiO4)
 
 # the following command creates Li4SiO4 with respect to given arguments but uses the default values for enrichment_target and enrichment_type
-enriched_and_packed_Li4SiO4 = Material('Li4SiO4', enrichment=60, packing_fraction=0.64).neutronics_material   # enrichment_target='Li6', enrichment_type='ao' defined by default
+enriched_and_packed_Li4SiO4 = Material('Li4SiO4', enrichment=60, packing_fraction=0.64).openmc_material   # enrichment_target='Li6', enrichment_type='ao' defined by default
 print(enriched_and_packed_Li4SiO4)
 
 # the following commant creates Li4SiO4 with respect to given arguments but specifies enrichment_target and enrichment_type explicitly

--- a/tasks/task_11/4_example_materials_parameter_study.py
+++ b/tasks/task_11/4_example_materials_parameter_study.py
@@ -13,7 +13,7 @@ from neutronics_material_maker import Material
 # We will show density as a function of temperature over a larger range, but at correct pressure
 
 temperatures = np.linspace(0.1, 600., 200)
-water_densities = [Material('H2O', temperature_in_C=temperature, pressure_in_Pa=15500000).neutronics_material.density for temperature in temperatures]
+water_densities = [Material('H2O', temperature_in_C=temperature, pressure_in_Pa=15500000).openmc_material.density for temperature in temperatures]
 
 fig = make_subplots(rows=2, cols=2,
                     subplot_titles=("Water density as a function of temperature (at constant pressure)", "Helium density as a function of temperature (at constant pressure)", "Helium density as a function of pressure (at constant temperature)", ""))
@@ -33,7 +33,7 @@ fig.update_yaxes({'title': 'Density (g/cm3)'}, row=1, col=1)
 # We will show density as a function of temperature over a larger range, but at correct pressure
 
 temperatures = np.linspace(0.1, 600., 200)
-helium_densities = [Material('He', temperature_in_C=temperature, pressure_in_Pa=8000000).neutronics_material.density for temperature in temperatures]
+helium_densities = [Material('He', temperature_in_C=temperature, pressure_in_Pa=8000000).openmc_material.density for temperature in temperatures]
 
 fig.add_trace(go.Scatter(x=temperatures,
                          y=helium_densities,
@@ -50,7 +50,7 @@ fig.update_yaxes({'title': 'Density (g/cm3)'}, row=1, col=2)
 # Pressure is kept constant in HCPB, however, this is just demonstrating the effect
 
 pressures = np.linspace(1000000., 10000000., 100)
-helium_densities = [Material('He', temperature_in_C=400, pressure_in_Pa=pressure).neutronics_material.density for pressure in pressures]
+helium_densities = [Material('He', temperature_in_C=400, pressure_in_Pa=pressure).openmc_material.density for pressure in pressures]
 
 fig.add_trace(go.Scatter(x=pressures,
                          y=helium_densities,

--- a/tasks/task_11/5_example_materials_mixed.py
+++ b/tasks/task_11/5_example_materials_mixed.py
@@ -14,15 +14,15 @@ mixed_helium_Li4SiO4 = MultiMaterial(material_name='mixed_helium_Li4SiO4',   # n
                                      materials=[helium, Li4SiO4],            # list of material objects (NOT neutronics materials)
                                      fracs=[0.36, 0.64],                     # list of combination fractions for each material object
                                      percent_type='vo')                      # combination fraction type
-# print(mixed_helium_Li4SiO4.neutronics_material)
+# print(mixed_helium_Li4SiO4.openmc_material)
 
 
 # Homogenous mixture of tungsten carbide and water using mix_materials function
 
 mixed_water_WC = openmc.Material.mix_materials(name='mixed_water_WC',      # name of homogeneous material
                                                materials=[                 # list of neutronics materials
-                                                   Material('WC').neutronics_material,
-                                                   Material('H2O', temperature_in_C=25, pressure_in_Pa=100000).neutronics_material
+                                                   Material('WC').openmc_material,
+                                                   Material('H2O', temperature_in_C=25, pressure_in_Pa=100000).openmc_material
                                                ],
                                                fracs=[0.8, 0.2],           # list of combination fractions for each neutronics material
                                                percent_type='vo')          # combination fraction type
@@ -30,15 +30,15 @@ mixed_water_WC = openmc.Material.mix_materials(name='mixed_water_WC',      # nam
 
 # Demonstration of changing combination fractions of each material
 
-print('Tungsten carbide density = ' + str(Material('WC').neutronics_material.density))
-print('Water density = ' + str(Material('H2O', temperature_in_C=25, pressure_in_Pa=100000).neutronics_material.density))
+print('Tungsten carbide density = ' + str(Material('WC').openmc_material.density))
+print('Water density = ' + str(Material('H2O', temperature_in_C=25, pressure_in_Pa=100000).openmc_material.density))
 
 water_fractions = np.linspace(0., 1., 20)
 
 mixed_water_WC_densities = [openmc.Material.mix_materials(name='mixed_water_WC',
                                                           materials=[
-                                                              Material('WC').neutronics_material,
-                                                              Material('H2O', temperature_in_C=25, pressure_in_Pa=100000).neutronics_material
+                                                              Material('WC').openmc_material,
+                                                              Material('H2O', temperature_in_C=25, pressure_in_Pa=100000).openmc_material
                                                           ],
                                                           fracs=[
                                                               water_fraction,


### PR DESCRIPTION
This updates the workshop to the latest syntax for the neutronics material maker python package.

This package recently changed .neutronics_material to .openmc_material