### PR TITLE
updated filepaths for trelis command

### DIFF
--- a/tasks/task_12/make_faceteted_neutronics_model.py
+++ b/tasks/task_12/make_faceteted_neutronics_model.py
@@ -76,7 +76,8 @@ def save_output_files():
 with open('manifest.json') as f:
     geometry_details = byteify(json.load(f))
 
-geometry_details = find_number_of_volumes_in_each_step_file(geometry_details, '/home/shimwell/openmc_workshop/tasks/task_12/')
+
+geometry_details = find_number_of_volumes_in_each_step_file(geometry_details, str(os.path.abspath('.')))
 
 tag_geometry_with_mats(geometry_details)
 

--- a/tasks/task_12/make_unstructured_mesh.py
+++ b/tasks/task_12/make_unstructured_mesh.py
@@ -77,7 +77,7 @@ input_locations = []
 for entry in data:
     if 'mesh' in entry.keys():
         input_locations.append(entry)
-geometry_details = find_number_of_volumes_in_each_step_file(input_locations, '/home/shimwell/openmc_workshop/tasks/task_12/')
+geometry_details = find_number_of_volumes_in_each_step_file(input_locations, str(os.path.abspath('.')))
 
 imprint_and_merge_geometry()
 


### PR DESCRIPTION
PR to update filepaths for trelis command to general filepaths.
This removes the need for users to manually edit the filepath.