### PR TITLE
removing moabs dirs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,7 @@ RUN mkdir MOAB && \
                   -DENABLE_BLASLAPACK=OFF \
                   -DCMAKE_INSTALL_PREFIX=/MOAB && \
     make -j"$compile_cores" install && \
+    rm -rf /MOAB/moab /MOAB/build && \
     cd pymoab && \
     bash install.sh && \
     python setup.py install


### PR DESCRIPTION
As discussed in #229 the github actions is failing to build the dockerfile due to running out of storage space

This PR attempts to decrease the dockerimage size