### PR TITLE
add cmake back to allow embree build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update -y && \
     apt-get install -y \
         wget git gfortran g++ \
         mpich libmpich-dev libhdf5-serial-dev libhdf5-mpich-dev \
-        hdf5-tools imagemagick && \
+        hdf5-tools imagemagick cmake && \
     apt-get autoremove  && \
     apt-get clean
 
@@ -89,11 +89,11 @@ RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev \
 # Clone and install Embree
 RUN mkdir embree && \
     cd embree && \
-    git clone --single-branch --branch master https://github.com/embree/embree.git  && \
+    git clone --single-branch --branch master https://github.com/embree/embree.git && \
     mkdir build && \
     cd build && \
     cmake ../embree -DCMAKE_INSTALL_PREFIX=/embree \
-             -DEMBREE_ISPC_SUPPORT=OFF && \
+                    -DEMBREE_ISPC_SUPPORT=OFF && \
     make -j"$compile_cores" && \
     make -j"$compile_cores" install && \
     rm -rf /embree/build /embree/embree
@@ -150,10 +150,10 @@ RUN mkdir DAGMC && \
     cmake ../DAGMC -DBUILD_TALLY=ON \
                    -DMOAB_DIR=/MOAB \
                    -DDOUBLE_DOWN=ON \
-                   -DDOUBLE_DOWN_DIR=/double-down \
                    -DBUILD_STATIC_EXE=OFF \
                    -DBUILD_STATIC_LIBS=OFF \
-                   -DCMAKE_INSTALL_PREFIX=/DAGMC/ && \
+                   -DCMAKE_INSTALL_PREFIX=/DAGMC/ \
+                   -DDOUBLE_DOWN_DIR=/double-down && \
     make -j"$compile_cores" install && \
     rm -rf /DAGMC/DAGMC /DAGMC/build
     


### PR DESCRIPTION
it appears cmake install via apt-get is needed in addition to the pip install cmake

Otherwise embree doesn't find cmake and the compile breaks

![Screenshot from 2021-01-29 12-44-41](https://user-images.githubusercontent.com/8583900/106277292-bd5ef000-6230-11eb-98c3-86ab8a9fbcf0.png)
