### PR TITLE
split dpa up to a per nuclide tally

### DIFF
--- a/tasks/task_06_CSG_cell_tally_DPA/1_find_dpa.ipynb
+++ b/tasks/task_06_CSG_cell_tally_DPA/1_find_dpa.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Task 6 - Simulating Displacements Per Atom (DPA)\n",
+    "# Simulating Displacements Per Atom (DPA)\n",
     "\n",
     "Displacements per atom (DPA) is one measure of damage within materials exposed to neutron irradiation. Damage energy can be tallied in OpenMC with MT reaction number 444 and DPA can be estimated.\n",
     "\n",
@@ -15,9 +15,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jshim/anaconda3/lib/python3.8/site-packages/IPython/core/display.py:717: UserWarning: Consider using IPython.display.IFrame instead\n",
+      "  warnings.warn(\"Consider using IPython.display.IFrame instead\")\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -27,7 +35,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -116,6 +124,7 @@
     "reaction_tally = openmc.Tally(name='DPA')\n",
     "reaction_tally.filters = [cell_filter]\n",
     "reaction_tally.scores = ['444']  # note use of 444 in string format\n",
+    "reaction_tally.nuclides = ['Fe54', 'Fe56', 'Fe57', 'Fe58'] # this records the tally for each nuclide in the list\n",
     "tallies.append(reaction_tally)"
    ]
   },
@@ -141,7 +150,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This extracts the simulation results and calculates the total number of displacements for all atoms. From here, DPA can be found."
+    "This extracts the simulation results and displays the damage-energy (444 MT number tally) for each nuclide"
    ]
   },
   {
@@ -155,10 +164,23 @@
     "# access the tally\n",
     "tally = sp.get_tally(name='DPA')\n",
     "\n",
-    "df = tally.get_pandas_dataframe()\n",
-    "\n",
+    "df = tally.get_pandas_dataframe()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This calculates the total number of displacements for all atoms by summing together the seperate damage-energy for each nuclide. From here, DPA can be found."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "damage_energy_in_ev = df['mean'].sum()\n",
-    "\n",
     "\n",
     "print('Damage energy deposited per source neutron = ', damage_energy_in_ev, 'eV\\n')\n",
     "\n",
@@ -281,5 +303,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tasks/task_06_CSG_cell_tally_DPA/1_find_dpa.ipynb
+++ b/tasks/task_06_CSG_cell_tally_DPA/1_find_dpa.ipynb
@@ -15,31 +15,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/jshim/anaconda3/lib/python3.8/site-packages/IPython/core/display.py:717: UserWarning: Consider using IPython.display.IFrame instead\n",
-      "  warnings.warn(\"Consider using IPython.display.IFrame instead\")\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<iframe width=\"560\" height=\"315\" src=\"https://youtube.com/embed/VLn59FSc4GA\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython.display import HTML\n",
     "HTML('<iframe width=\"560\" height=\"315\" src=\"https://youtube.com/embed/VLn59FSc4GA\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>')"
@@ -164,7 +142,9 @@
     "# access the tally\n",
     "tally = sp.get_tally(name='DPA')\n",
     "\n",
-    "df = tally.get_pandas_dataframe()\n"
+    "df = tally.get_pandas_dataframe()\n",
+    "\n",
+    "df"
    ]
   },
   {


### PR DESCRIPTION
This PR changes a tally so that the results are presented per nuclide as requested in #246 

The dataframe shows DPA for Iron

![Screenshot from 2021-03-09 12-56-58](https://user-images.githubusercontent.com/8583900/110651396-50396580-81b3-11eb-9a48-15a014e67af5.png)


This is not quite broken down to a mterial level but one step towards what you wanted @bruceey42
