### PR TITLE
MOAB version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get --yes update && apt-get --yes upgrade
 
                           # eigen3 needed for DAGMC
 RUN apt-get --yes install libeigen3-dev \
-                        #   sudo  \ 
+                        #   sudo  \
                           # sudo is needed during the NJOY install
                           git \
                           wget \
@@ -113,7 +113,7 @@ RUN mkdir embree && \
 # Clone and install MOAB
 RUN mkdir MOAB && \
     cd MOAB && \
-    git clone  --single-branch --branch 5.2.1 --depth 1 https://bitbucket.org/fathomteam/moab.git && \
+    git clone  --single-branch --branch 5.3.0 --depth 1 https://bitbucket.org/fathomteam/moab.git && \
     mkdir build && \
     cd build && \
     cmake ../moab -DENABLE_HDF5=ON \
@@ -137,7 +137,7 @@ RUN mkdir MOAB && \
     # the following rm command appears to remove libraries that are need to use
     # pymoab so this has been commented out for now
     # rm -rf /MOAB/moab /MOAB/build
-    
+
 ENV PATH=$PATH:/MOAB/bin
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/MOAB/lib
 
@@ -154,7 +154,7 @@ RUN mkdir double-down && \
                          -DEMBREE_DIR=/embree && \
     make -j"$compile_cores" && \
     make -j"$compile_cores" install && \
-    rm -rf /double-down/build /double-down/double-down 
+    rm -rf /double-down/build /double-down/double-down
 
 
 # DAGMC version 3.2.0 install from source
@@ -173,7 +173,7 @@ RUN mkdir DAGMC && \
     make -j"$compile_cores" install && \
     rm -rf /DAGMC/DAGMC /DAGMC/build
 
-ENV PATH=$PATH:/DAGMC/bin    
+ENV PATH=$PATH:/DAGMC/bin
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/DAGMC/lib
 
 
@@ -188,7 +188,7 @@ RUN cd /opt && \
           -DDAGMC_ROOT=/DAGMC \
           -DHDF5_PREFER_PARALLEL=off ..  && \
     make -j"$compile_cores" && \
-    make -j"$compile_cores" install && \ 
+    make -j"$compile_cores" install && \
     cd /opt/openmc/ && \
     pip install .
 


### PR DESCRIPTION
This updates the version of MOAB in the Dockerfile to one that includes the thread-safety fix from [this PR](https://bitbucket.org/fathomteam/moab/pull-requests/529).

Looks like my editor also removed some trialing whitespace... sorry for the extra noise in the diff!